### PR TITLE
Add Generative Sequencer firmware for Hagiwo Sync Mod LFO.

### DIFF
--- a/Modules/HAGIWO/Sync LFO/Firmware/GenerativeSeq_SyncLFO.ino
+++ b/Modules/HAGIWO/Sync LFO/Firmware/GenerativeSeq_SyncLFO.ino
@@ -1,0 +1,108 @@
+/**
+ * @file GenerativeSeq_SyncLFO.ino
+ * @author Adam Wonak (https://github.com/awonak/)
+ * @brief Generative Sequencer firmware for HAGIWO Sync Mod LFO (demo: https://youtu.be/okj47TcXJXg)
+ * @version 0.1
+ * @date 2023-03-26
+ *
+ * @copyright Copyright (c) 2023
+ *
+ */
+// Install the "AVR Standard C Time Libaray", used for faster PWM frequencies
+// and smoother analog cv output.
+#include <avr/io.h>
+
+// GPIO Pin mapping for knobs and jacks.
+#define P1 0 // Probability
+#define P2 1 // Sequence step length
+#define P3 3 // Amplitiude
+#define P4 5 // Refrain count
+
+#define CLOCK_IN 3
+#define PWM_OUT 10
+
+#define DEBUG
+
+// State variables.
+bool clock_in, old_clock_in;
+int probability, steps, amplititude;
+
+int output;
+int step;
+int refrain_counter;
+int rand_val;
+
+int refrain = 1;
+int refrain_max = 4;
+int pattern_size_max = 16;
+int cv_max = 1023;
+int cv_pattern[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+int pattern_options[8] = {1, 2, 3, 4, 6, 8, 12, 16};
+
+void setup()
+{
+    Serial.begin(9600);
+    pinMode(CLOCK_IN, INPUT);
+    pinMode(PWM_OUT, OUTPUT);
+
+    // Fast PWM configuration.
+    TCCR1A = 0b00100001;
+    TCCR1B = 0b00100001;
+    delay(50);
+
+    // Inititialize random values in sequence.
+    for (int i = 0; i < pattern_size_max; i++)
+    {
+        cv_pattern[i] = random(cv_max);
+    }
+}
+
+void loop()
+{
+    // Read clock input.
+    old_clock_in = clock_in;
+    clock_in = digitalRead(CLOCK_IN);
+
+    // Check for new clock trigger.
+    if (old_clock_in == 0 && clock_in == 1)
+    {
+        // Increment the current sequence step.
+        // Right shift to scale input to a range of 8.
+        steps = pattern_options[(analogRead(P2) >> 7)];
+        step = (step + 1) % steps;
+
+        // Increment Refrain at the first step of the sequence.
+        if (step == 0)
+        {
+            // Right shift to scale input to a range of 4.
+            refrain = (analogRead(P4) >> 8) + 1;
+            refrain_counter = (refrain_counter + 1) % refrain;
+        }
+
+        // Check probability and refrain counter to see if the current step
+        // should be updated.
+        probability = analogRead(P1);
+        rand_val = random(cv_max);
+        if (refrain_counter == 0 && probability > rand_val)
+        {
+            cv_pattern[step] = random(cv_max);
+        }
+
+        debug();
+    }
+
+    // Scale amplititude down to a range of 255 to match PWM range.
+    amplititude = analogRead(P3) >> 2;
+
+    // Update PWM CV output value.
+    output = map(cv_pattern[step], 0, cv_max, 0, amplititude);
+    analogWrite(PWM_OUT, output);
+}
+
+void debug()
+{
+#ifdef DEBUG
+    Serial.println(
+        "Prob: " + String(probability) + " > " + String(rand_val) + "\tValue: " + String(cv_pattern[step]) + "\tRefrain: [" + String(refrain_counter) + "/" + String(refrain) + "]" + "\tSteps: [" + String(step) + "/" + String(steps) + "]" + "\tAmp: " + String(amplititude));
+#endif
+}

--- a/Modules/HAGIWO/Sync LFO/Firmware/GenerativeSeq_SyncLFO.ino
+++ b/Modules/HAGIWO/Sync LFO/Firmware/GenerativeSeq_SyncLFO.ino
@@ -8,6 +8,7 @@
  * @copyright Copyright (c) 2023
  *
  */
+
 // Install the "AVR Standard C Time Libaray", used for faster PWM frequencies
 // and smoother analog cv output.
 #include <avr/io.h>
@@ -21,7 +22,8 @@
 #define CLOCK_IN 3
 #define PWM_OUT 10
 
-#define DEBUG
+// Uncomment to print state to serial monitoring output.
+// #define DEBUG
 
 // State variables.
 bool clock_in, old_clock_in;


### PR DESCRIPTION
Add a new firmware for the Hagiwo Sync Mod LFO hardware.

Generative Sequencer - Inspired by https://note.com/solder_state/n/n8a489f0b857a

Demo video: https://youtu.be/okj47TcXJXg

**Features:**
[Knobs]
- Probability: increase chance for updating the current step with a new random voltage
- Sequence step length: repeat random voltages in a sequence of 1, 2, 3, 4, 6, 8, 12, or 16 steps.
- Amplitude: scale the output voltage between 0v - 10v.
- Refrain: the number of times the sequence must repeat before allowing new random voltage.

[Jacks]
- Clock In: Trigger input to advance the sequence to the next step.
- Out: Repeating random cv sequence, scaled by Amplititude knob. 0v to 10v
- Inv: Inverted output 10v to 0v
- Bi: Bi-polar output +10v to -10v

